### PR TITLE
[FIX #3] Recolectamos los candidatos de un voto y no permitimos que se duplique su voto.

### DIFF
--- a/msa/core/clases.py
+++ b/msa/core/clases.py
@@ -427,7 +427,7 @@ class Recuento(object):
                 if candidato_key not in candidatos_sumados:
                     self._resultados[candidato.cod_categoria,
                                      candidato.codigo] += 1
-                    candidatos_sumados.append(candidato_key)
+                    candidatos_sumados.add(candidato_key)
                 else:
                     # Si llegamos a este punto es porque se ha
                     # leído una tarjeta hackeada. Que hacemos con ella?


### PR DESCRIPTION
Cada selección es acumulada en candidatos_sumados, de esta manera si encontramos una votación en el conjunto es porque se duplicó la entrada de ese candidato en la boleta. En otras palabras ocurrió un voto fraudulento.
